### PR TITLE
Ensure that scores array is always writeable

### DIFF
--- a/sed_scores_eval/base_modules/statistics.py
+++ b/sed_scores_eval/base_modules/statistics.py
@@ -216,6 +216,8 @@ def _worker(
         timestamps, _ = validate_score_dataframe(
             scores_for_key, event_classes=event_classes)
         scores_for_key = scores_for_key[event_classes].to_numpy()
+        if not scores_for_key.flags.writeable:
+            scores_for_key = scores_for_key.copy()
         deltas[audio_id] = {}
         gt_onset_times = {}
         gt_offset_times = {}


### PR DESCRIPTION
Under certain circumstances (e.g., only one column is read out), DataFrame.to_numpy() only returns a (non-writeable) view of the array (https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_numpy.html). This throws an error in onset_offset_curves, so we have to make sure that the array is writeable.